### PR TITLE
Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 dist/
+build/
 *.egg-info/
 .ipynb_checkpoints
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - provider: pypi
           user: carlodef
           password:
-              YOUR_ENCRYPTED_PASSWORD_HERE
+              secure: "qTN2mT3LGMZQdnYyZrGHtH5KktRSHnV2L41C3Phl6YmLu15B7u9zoY1cnoLDYgnoKRzySItoXhOFX6teMb0V/N/W8yPXiQ8yPqoeu/aTEJlESFHK3J0kSufJRTxFnmD0gNLEudYVpCkAQsJIq9v+EEu4k0tflJH2s6uHdJg1TTuzkePtMDrKFHyhbp4vMg3ySIUSjmI3T+c9x6due81qcY7+50m5A0EnTPfE7VaR1Hci61pQsLNDUs4SMoEyStjY2PecOm1Pu73t14Kq1JLFio/OgrF0GrS8DwzJn7NChiWj/nSa/Eea7Q5po9yMtqkgqTZbwnfYEs1ELOzqidan/zRgrennOy0g/MghZQfw7hzEpcaMRgKyltaaGa5uOyXsPp8laacfinN6uxtEuMpLWfpmkwObSsQQGlAETKJEPIT7+7ogp0mhk10qBQzVf0tdc9hfXGLTQXmlBourG4fGad25pehhkmEPeZrbdrb9Bl4bG0bwIyqVxoPZAeDXcRBWqZeTnOfeHUBB+PS9i8FVZ/9Nr9GkrQTFaWM3MMvSigWAAHFgOFmGyEpTI5CYKNzOdnAUqKpZMbf0wZ8uXc6IVHrbKFeDezulOMaR1anmCV8JVSQK5MiJkan+UMJVnTaGRk9BRhtcGOolQ96oqPWwLXl/q7/S5VwzTYejQNfq7Hg="
           distributions: sdist bdist_wheel
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+os: linux
+dist: xenial
+language: python
+python: 3.7
+
+install: pip install -e .
+script: bash tests/tests.sh
+
+jobs:
+  include:
+    - stage: test
+    - stage: test
+      python: 2.7
+
+    - stage: deploy
+      if: tag IS present AND repo = cmla/rpcm
+      install: skip
+      script: skip
+      deploy:
+        - provider: pypi
+          user: carlodef
+          password:
+              YOUR_ENCRYPTED_PASSWORD_HERE
+          distributions: sdist bdist_wheel
+          on:
+            tags: true

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+# exit on errors. It's far from perfect, but better than nothing:
+# http://mywiki.wooledge.org/BashFAQ/105
+set -e
+
 IMG1="http://menthe.ovh.hw.ipol.im/IARPA_data/cloud_optimized_geotif/01SEP15WV031000015SEP01135603-P1BS-500497284040_01_P001_________AAE_0AAAAABPABP0.TIF"
 IMG2="http://menthe.ovh.hw.ipol.im/IARPA_data/cloud_optimized_geotif/02APR15WV031000015APR02134716-P1BS-500276959010_02_P001_________AAE_0AAAAABPABB0.TIF"
 


### PR DESCRIPTION
This PR adds Travis CI with test and deploy stages.

The test is simply a run of the `tests/tests.sh` script, it can be turned into a proper `pytest` suite in a future PR.

The deploy to PyPI requires some configuration on @carlodef's side.
In order to generate an encrypted password, you need to:
1. Make sure you have the command `gem` installed (if not, I think you simply need to `brew install ruby`, but I'm not 100% sure)
2. `gem install travis`
3. `travis login -M --pro --github-token $GITHUB_TOKEN`.
The `--pro` means that you want to "login" to `travis-ci.com` and not `travis-ci.org` (the latter being deprecated). The `travis` command is a bit annoying to use, apparently you need to add `--pro` to each command you run...
4. At the root of your repo, run `travis encrypt $YOUR_PYPI_PASSWORD --pro`.
The tool might interactively ask you to confirm that they have correctly "auto-detected" in which repo you are. This is important to get right, because the encryption is done on a per-repo basis.
5. The previous step will print something such as:
```
secure: "iO46xLhGCvVnpYbD3zo4Qu0Cj5e....."
```
Place this line in the `.travis.yml` instead of the `YOUR_ENCRYPTED_PASSWORD_HERE` I have included.

You can then try to make a `1.4.1` release to see if everything works fine (I have tested it on my fork on the test PyPI and it does).