### PR TITLE
Read RPC string

### DIFF
--- a/rpcm/rpc_file_readers.py
+++ b/rpcm/rpc_file_readers.py
@@ -4,8 +4,6 @@
 
 
 from __future__ import print_function
-import copy
-import numpy as np
 from xml.etree import ElementTree
 
 


### PR DESCRIPTION
This feature changes the functions `read_rpc_ikonos` and `read_rpc_xml` to take a string as input, not a filepath. Reading from the filepath is now handled by the higher-level `read_rpc_file`.

This enables a user with a string to instantiate an `RPCModel` without having to write the string to disk.