### PR TITLE
Close comparison

### DIFF
--- a/rpcm/rpc_model.py
+++ b/rpcm/rpc_model.py
@@ -387,11 +387,11 @@ class RPCModel:
         two RPCModel instances are equal
         """
         return (
-            self.row_offset == other.row_offset
-            and self.col_offset == other.col_offset
-            and self.lat_offset == other.lat_offset
-            and self.lon_offset == other.lon_offset
-            and self.alt_offset == other.alt_offset
+            np.allclose(self.row_offset, other.row_offset)
+            and np.allclose(self.col_offset, other.col_offset)
+            and np.allclose(self.lat_offset, other.lat_offset)
+            and np.allclose(self.lon_offset, other.lon_offset)
+            and np.allclose(self.alt_offset, other.alt_offset)
         )
 
     def equal_scales(self, other):
@@ -400,11 +400,11 @@ class RPCModel:
         two RPCModel instances are equal
         """
         return (
-            self.row_scale == other.row_scale
-            and self.col_scale == other.col_scale
-            and self.lat_scale == other.lat_scale
-            and self.lon_scale == other.lon_scale
-            and self.alt_scale == other.alt_scale
+            np.allclose(self.row_scale, other.row_scale)
+            and np.allclose(self.col_scale, other.col_scale)
+            and np.allclose(self.lat_scale, other.lat_scale)
+            and np.allclose(self.lon_scale, other.lon_scale)
+            and np.allclose(self.alt_scale, other.alt_scale)
         )
 
     def equal_projection(self, other):
@@ -413,10 +413,10 @@ class RPCModel:
         functions of two RPCModel instances are equal
         """
         return (
-            self.row_num == other.row_num
-            and self.row_den == other.row_den
-            and self.col_num == other.col_num
-            and self.col_den == other.col_den
+            np.allclose(self.row_num, other.row_num)
+            and np.allclose(self.row_den, other.row_den)
+            and np.allclose(self.col_num, other.col_num)
+            and np.allclose(self.col_den, other.col_den)
         )
 
     def equal_localization(self, other):
@@ -426,10 +426,10 @@ class RPCModel:
         """
         if hasattr(self, "lat_num"):
             equal_localization = (
-                self.lon_num == other.lon_num
-                and self.lon_den == other.lon_den
-                and self.lat_num == other.lat_num
-                and self.lat_den == other.lat_den
+                np.allclose(self.lon_num, other.lon_num)
+                and np.allclose(self.lon_den, other.lon_den)
+                and np.allclose(self.lat_num, other.lat_num)
+                and np.allclose(self.lat_den, other.lat_den)
             )
         else:
             equal_localization = True

--- a/tests/test_rpc_comparison.py
+++ b/tests/test_rpc_comparison.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import pytest
@@ -8,15 +9,24 @@ here = os.path.abspath(os.path.dirname(__file__))
 files_dir = os.path.join(here, "test_rpc_files")
 
 
-def rpc_files():
+@pytest.fixture()
+def rpc1():
     """
-    Fixture to the RPC files used for the tests
+    Planet L1A RPC fixture
     """
-    filenames = ["rpc_PLANET_L1{}.txt".format(a_b) for a_b in ["A", "B"]]
-    return [[rpc_from_rpc_file(os.path.join(files_dir, filename)) for filename in filenames]]
+    filename = "rpc_PLANET_L1A.txt"
+    return rpc_from_rpc_file(os.path.join(files_dir, filename))
 
 
-@pytest.mark.parametrize("rpc1, rpc2", rpc_files())
+@pytest.fixture()
+def rpc2():
+    """
+    Planet L1B RPC fixture
+    """
+    filename = "rpc_PLANET_L1B.txt"
+    return rpc_from_rpc_file(os.path.join(files_dir, filename))
+
+
 def test_rpc_comparison(rpc1, rpc2):
     """
     This test is run on two RPCs coming from Planet Skysat images,
@@ -29,3 +39,13 @@ def test_rpc_comparison(rpc1, rpc2):
     assert not rpc1.equal_offsets(rpc2)
     assert not rpc1.equal_scales(rpc2)
     assert rpc1.equal_projection(rpc2)
+
+
+@pytest.mark.parametrize("shift, equal", [(1e-8, True), (1e-3, False)])
+def test_rpc_close_comparison(rpc1, shift, equal):
+    rpc2 = copy.deepcopy(rpc1)
+    rpc2.col_num = [coeff + shift for coeff in rpc2.col_num]
+    if equal:
+        assert rpc2 == rpc1
+    else:
+        assert rpc2 != rpc1


### PR DESCRIPTION
This PR fixes a bug in RPC comparison.

An `==` expression was used to compare RPC coefficients, which could evaluate to `False` in cases where the coefficients are numerically very close but not equal.

The `==` has been replaced with `np.allclose` to account for that, and tests have been added to cover this edge case.